### PR TITLE
Guard IndexedDB open and delete against never settling

### DIFF
--- a/src/Browserbase.spec.ts
+++ b/src/Browserbase.spec.ts
@@ -1,5 +1,5 @@
 import indexeddb, { IDBKeyRange, IDBTransaction } from 'fake-indexeddb';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Browserbase, ObjectStore } from './Browserbase';
 
 // Skipping files that produce errors because either vitest isn't catching them, or fake-indexeddb is throwing them
@@ -475,5 +475,218 @@ describe('Browserbase', () => {
       { key: 'test4', name: 'b', date: new Date('2010-01-01') },
       { key: 'test5', name: 'b', date: new Date('2000-01-01') },
     ]);
+  });
+});
+
+describe('Browserbase open lifecycle guards', () => {
+  const defaultOpenTimeout = Browserbase.openTimeout;
+  const defaultUpgradeTimeout = Browserbase.upgradeTimeout;
+
+  afterEach(() => {
+    Browserbase.openTimeout = defaultOpenTimeout;
+    Browserbase.upgradeTimeout = defaultUpgradeTimeout;
+    vi.restoreAllMocks();
+  });
+
+  const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+  const newDb = () => new Browserbase('guards' + (Math.random() + '').slice(2), { dontDispatch: true });
+
+  const fakeTransaction = () => ({ objectStore: () => ({ keyPath: 'key', createIndex() {}, deleteIndex() {} }) });
+
+  // A hand-driven stand-in for IDBOpenDBRequest, so tests can fire events at will — or withhold them entirely.
+  function stubOpen() {
+    const request: any = {
+      result: null,
+      transaction: null,
+      onsuccess: null,
+      onerror: null,
+      onblocked: null,
+      onupgradeneeded: null,
+    };
+    vi.spyOn(indexedDB, 'open').mockReturnValue(request);
+    return request;
+  }
+
+  function fakeDatabase() {
+    const names: any = ['foo'];
+    names.contains = (name: string) => names.includes(name);
+    return {
+      closed: false,
+      objectStoreNames: names,
+      transaction: fakeTransaction,
+      close() {
+        this.closed = true;
+      },
+      onerror: null,
+      onabort: null,
+      onversionchange: null,
+      onclose: null,
+    } as any;
+  }
+
+  it('should reject a blocked open only after the timeout, so a brief block can clear', async () => {
+    Browserbase.openTimeout = 40;
+    const request = stubOpen();
+    const db = newDb();
+    db.version(1, { foo: 'key' });
+
+    let state = 'pending';
+    const opening = db.open().then(
+      () => (state = 'resolved'),
+      err => {
+        state = 'rejected';
+        return err;
+      }
+    );
+    request.onblocked({ oldVersion: 1, newVersion: 2 });
+
+    await delay(20);
+    expect(state).to.equal('pending');
+
+    const error = await opening;
+    expect(state).to.equal('rejected');
+    expect(error.name).to.equal('BlockedError');
+    expect(error.message).toContain(db.name);
+  });
+
+  it('should open normally when a blocked open clears before the timeout', async () => {
+    Browserbase.openTimeout = 100;
+    const request = stubOpen();
+    const db = newDb();
+    db.version(1, { foo: 'key' });
+
+    const opening = db.open();
+    request.onblocked({ oldVersion: 1, newVersion: 2 });
+
+    await delay(20);
+    const opened = fakeDatabase();
+    request.result = opened;
+    request.onsuccess();
+
+    await opening;
+    expect(db.db).toBe(opened);
+    expect(opened.closed).toBe(false);
+  });
+
+  it('should reject the open when no event ever fires', async () => {
+    Browserbase.openTimeout = 20;
+    stubOpen();
+    const db = newDb();
+    db.version(1, { foo: 'key' });
+
+    const error = await db.open().catch(err => err);
+    expect(error.name).to.equal('TimeoutError');
+    expect(error.message).toContain('20ms');
+  });
+
+  it('should close a database that opens after the timeout rejected', async () => {
+    Browserbase.openTimeout = 20;
+    Browserbase.upgradeTimeout = 20;
+    const request = stubOpen();
+    const db = newDb();
+    db.version(1, { foo: 'key' });
+
+    const opening = db.open().catch(err => err);
+    const late = fakeDatabase();
+    request.result = late;
+    request.transaction = fakeTransaction();
+    request.onupgradeneeded({ oldVersion: 0 });
+
+    await delay(50);
+    request.onsuccess();
+
+    expect((await opening).name).to.equal('TimeoutError');
+    expect(late.closed).toBe(true);
+    expect(db.db).toBe(null);
+  });
+
+  it('should re-arm the timeout on upgradeneeded but still reject a stalled upgrade', async () => {
+    Browserbase.openTimeout = 20;
+    Browserbase.upgradeTimeout = 80;
+    const request = stubOpen();
+    const db = newDb();
+    db.version(1, { foo: 'key' });
+
+    let state = 'pending';
+    const opening = db.open().then(
+      () => (state = 'resolved'),
+      err => {
+        state = 'rejected';
+        return err;
+      }
+    );
+
+    request.result = fakeDatabase();
+    request.transaction = fakeTransaction();
+    request.onupgradeneeded({ oldVersion: 0 });
+
+    await delay(45);
+    expect(state).to.equal('pending');
+
+    const error = await opening;
+    expect(state).to.equal('rejected');
+    expect(error.name).to.equal('TimeoutError');
+    expect(error.message).toContain('80ms');
+  });
+
+  it('should open normally when an upgrade finishes within its budget', async () => {
+    Browserbase.openTimeout = 20;
+    Browserbase.upgradeTimeout = 500;
+    const request = stubOpen();
+    const db = newDb();
+    db.version(1, { foo: 'key' });
+
+    const opening = db.open();
+    const opened = fakeDatabase();
+    request.result = opened;
+    request.transaction = fakeTransaction();
+    request.onupgradeneeded({ oldVersion: 0 });
+
+    await delay(45);
+    request.onsuccess();
+
+    await opening;
+    expect(db.db).toBe(opened);
+    expect(db.stores).to.have.property('foo');
+    expect(opened.closed).toBe(false);
+  });
+
+  it('should reject deleteDatabase when an open connection blocks it', async () => {
+    const request: any = { error: null, onsuccess: null, onerror: null, onblocked: null };
+    vi.spyOn(indexedDB, 'deleteDatabase').mockReturnValue(request);
+
+    const deleting = Browserbase.deleteDatabase('blocked-db').catch(err => err);
+    request.onblocked();
+
+    const error = await deleting;
+    expect(error.name).to.equal('BlockedError');
+    expect(error.message).toContain('blocked-db');
+  });
+
+  it('should reject deleteDatabase with a real error when the request has none', async () => {
+    const request: any = { error: null, onsuccess: null, onerror: null, onblocked: null };
+    vi.spyOn(indexedDB, 'deleteDatabase').mockReturnValue(request);
+
+    const deleting = Browserbase.deleteDatabase('null-error-db').catch(err => err);
+    request.onerror();
+
+    const error = await deleting;
+    expect(error).to.be.instanceOf(Error);
+    expect(error.message).toContain('null-error-db');
+  });
+
+  it('should return the same promise when open is called twice concurrently', async () => {
+    const open = vi.spyOn(indexedDB, 'open');
+    const db = newDb();
+    db.version(1, { foo: 'key' });
+
+    const first = db.open();
+    const second = db.open();
+    expect(second).toBe(first);
+
+    await first;
+    expect(open).toHaveBeenCalledTimes(1);
+    db.close();
   });
 });

--- a/src/Browserbase.spec.ts
+++ b/src/Browserbase.spec.ts
@@ -617,7 +617,8 @@ describe('Browserbase open lifecycle guards', () => {
       }
     );
 
-    request.result = fakeDatabase();
+    const upgrading = fakeDatabase();
+    request.result = upgrading;
     request.transaction = fakeTransaction();
     request.onupgradeneeded({ oldVersion: 0 });
 
@@ -628,6 +629,9 @@ describe('Browserbase open lifecycle guards', () => {
     expect(state).to.equal('rejected');
     expect(error.name).to.equal('TimeoutError');
     expect(error.message).toContain('80ms');
+    // The connection handed over during upgrade must not leak, and isOpen() must stay false.
+    expect(upgrading.closed).toBe(true);
+    expect(db.db).toBe(null);
   });
 
   it('should open normally when an upgrade finishes within its budget', async () => {

--- a/src/Browserbase.ts
+++ b/src/Browserbase.ts
@@ -241,6 +241,11 @@ export class Browserbase<Stores extends ObjectStoreMap<Stores> = {}> extends Typ
         if (settled) return;
         settled = true;
         clearTimeout(timer);
+        // An upgrade may have already handed us the connection; don't leak it (or leave isOpen() true) on failure.
+        if (this.db && this.db === request.result) {
+          this.db = null;
+          request.result.close();
+        }
         // request.error can be null in real browsers; never reject with nothing.
         reject(error || namedError('UnknownError', `Opening database '${this.name}' failed`));
       };

--- a/src/Browserbase.ts
+++ b/src/Browserbase.ts
@@ -116,10 +116,26 @@ const transactionPromise = new WeakMap<IDBTransaction, Promise<any>>();
  */
 export class Browserbase<Stores extends ObjectStoreMap<Stores> = {}> extends TypedEventTarget<BrowserbaseEventMap> {
   /**
+   * Milliseconds to wait for indexedDB.open() to fire any event at all before giving up. Some browsers never do.
+   */
+  static openTimeout = 4000;
+
+  /**
+   * Milliseconds to wait for an upgrade to finish once upgradeneeded has fired.
+   */
+  static upgradeTimeout = 30000;
+
+  /**
    * Deletes a database by name.
    */
   static deleteDatabase(name: string) {
-    return requestToPromise(indexedDB.deleteDatabase(name));
+    return new Promise<void>((resolve, reject) => {
+      const request = indexedDB.deleteDatabase(name);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error || new Error(`Deleting database '${name}' failed`));
+      request.onblocked = () =>
+        reject(namedError('BlockedError', `Deleting database '${name}' is blocked by an open connection`));
+    });
   }
 
   db: IDBDatabase | null;
@@ -199,8 +215,40 @@ export class Browserbase<Stores extends ObjectStoreMap<Stores> = {}> extends Typ
 
     return (this._opening = new Promise<IDBDatabase>((resolve, reject) => {
       let request = indexedDB.open(this.name, version);
-      request.onsuccess = successHandler(resolve);
-      request.onerror = errorHandler(reject, this);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let settled = false;
+
+      // Some browsers never fire any event on the open request, leaving callers hanging forever. Give up after a while.
+      const guard = (ms: number, error: Error) => {
+        clearTimeout(timer);
+        timer = setTimeout(() => fail(error), ms);
+      };
+      const timeoutError = (action: string, ms: number) =>
+        namedError('TimeoutError', `${action} '${this.name}' timed out after ${ms}ms`);
+
+      const succeed = (db: IDBDatabase) => {
+        if (settled) {
+          // Landed after we gave up on it, so don't leak the connection.
+          if (this.db === db) this.db = null;
+          return db.close();
+        }
+        settled = true;
+        clearTimeout(timer);
+        resolve(db);
+      };
+
+      const fail = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        // request.error can be null in real browsers; never reject with nothing.
+        reject(error || namedError('UnknownError', `Opening database '${this.name}' failed`));
+      };
+
+      guard(Browserbase.openTimeout, timeoutError('Opening database', Browserbase.openTimeout));
+
+      request.onsuccess = () => succeed(request.result);
+      request.onerror = errorHandler(fail, this);
       request.onblocked = event => {
         const blockedEvent = new Event('blocked', { cancelable: true });
         this.dispatchEvent(blockedEvent);
@@ -211,22 +259,35 @@ export class Browserbase<Stores extends ObjectStoreMap<Stores> = {}> extends Typ
             console.warn(`Upgrade '${this.name}' blocked by other connection holding version ${event.oldVersion}`);
           }
         }
+        // A blocked open usually clears in moments (the other tab closes on versionchange), so keep waiting, but
+        // bounded: if it never clears, surface why instead of the generic timeout.
+        guard(
+          Browserbase.openTimeout,
+          namedError('BlockedError', `Opening database '${this.name}' is blocked by a connection in another tab`)
+        );
       };
       request.onupgradeneeded = event => {
+        guard(Browserbase.upgradeTimeout, timeoutError('Upgrading database', Browserbase.upgradeTimeout));
         this.db = request.result;
-        this.db.onerror = errorHandler(reject, this);
-        this.db.onabort = errorHandler(() => reject(new Error('Abort')), this);
+        this.db.onerror = errorHandler(fail, this);
+        this.db.onabort = errorHandler(() => fail(new Error('Abort')), this);
         let oldVersion = event.oldVersion > Math.pow(2, 62) ? 0 : event.oldVersion; // Safari 8 fix.
         upgradedFrom = oldVersion;
         upgrade(oldVersion, request.transaction, this.db, this._versionMap, this._versionHandlers, this);
       };
-    }).then(db => {
-      this.db = db;
-      onOpen(this);
-      if (upgradedFrom === 0) this.dispatchEvent(new Event('create'));
-      else if (upgradedFrom) this.dispatchEvent(new CustomEvent('upgrade', { detail: { upgradedFrom } }));
-      this.dispatchEvent(new Event('open'));
-    }));
+    })
+      .then(db => {
+        this.db = db;
+        onOpen(this);
+        if (upgradedFrom === 0) this.dispatchEvent(new Event('create'));
+        else if (upgradedFrom) this.dispatchEvent(new CustomEvent('upgrade', { detail: { upgradedFrom } }));
+        this.dispatchEvent(new Event('open'));
+      })
+      .catch(error => {
+        // Let callers retry instead of handing them the same failure forever.
+        this._opening = undefined;
+        throw error;
+      }));
   }
 
   /**
@@ -838,6 +899,12 @@ function requestToPromise<T = unknown>(
     if (request.onerror === null) request.onerror = errorHandler(reject, errorDispatcher);
     if (request.onabort === null) request.onabort = () => reject(new Error('Abort'));
   });
+}
+
+function namedError(name: string, message: string) {
+  const error = new Error(message);
+  error.name = name;
+  return error;
 }
 
 function successHandler(resolve: (result: any) => void) {


### PR DESCRIPTION
**TL;DR:** If the browser's database layer stalls while Dabble is starting up (a known real-world failure), the app currently hangs forever on a blank screen with no error. After this change it fails fast with a clear error instead, so the app can react and users aren't left staring at nothing.

## What

`indexedDB.open()` can hang forever in three audited ways, and `deleteDatabase` in one:

- **No event ever fires** (crashed IDB backend, observed in Sentry): the open promise never settles. Now a hard guard (`Browserbase.openTimeout`, default 4s) rejects with `TimeoutError`.
- **Blocked by another tab holding an older version**: previously only the cancelable `blocked` event fired and the promise waited forever. A blocked open usually clears in moments (the other tab closes on `versionchange`), so the guard keeps waiting but re-arms; if it never clears it rejects with `BlockedError` naming the cause.
- **Stalled upgrade transaction**: `upgradeneeded` fires, then nothing. The guard re-arms with a longer budget (`Browserbase.upgradeTimeout`, default 30s) instead of running unbounded.
- **`deleteDatabase` blocked** by an open connection never settled; it now rejects with `BlockedError`, and a null `request.error` is wrapped in a real Error instead of rejecting with null.

A database that finishes opening after the guard already rejected is closed rather than leaked, and a failed open clears the cached in-flight promise so callers can retry.

## Tests

Nine new specs drive a hand-stubbed `IDBOpenDBRequest`: blocked-then-cleared opens succeed, blocked-forever rejects after the budget, silent opens time out, stalled upgrades reject at the re-armed budget while normal upgrades succeed, late-landing opens are closed, deleteDatabase blocked/null-error cases, and double-open returns the same promise. 34 passing, tsc clean.